### PR TITLE
Fix path to testem

### DIFF
--- a/tasks/grunt-contrib-testem.coffee
+++ b/tasks/grunt-contrib-testem.coffee
@@ -132,7 +132,8 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'testem:launchers', 'List available launchers', ->
     done = @async()
-    grunt.util.spawn {cmd: "node_modules/.bin/testem", args: ['launchers'], opts: {stdio: [0,1,2]}}, done
+    testemPath = __dirname + "/../node_modules/.bin/testem"
+    grunt.util.spawn {cmd: , testemPath, args: ['launchers'], opts: {stdio: [0,1,2]}}, done
 
   grunt.registerTask 'testem:ci', 'Run some environments in CI mode', ->
     grunt.option('reporter', 'dot') unless grunt.option('reporter')


### PR DESCRIPTION
When using grunt-contrib-testem as a grunt task, `spawn` cannot find the testem binary, issuing error message

```
execvp(): No such file or directory
Fatal error: spawn ENOENT
```

This patch updates the path so that it is relative to the path of the task file.
