### PR TITLE
Allow reporting output file to be configured and written to after test

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -53,5 +53,33 @@ module.exports = (grunt) ->
           parallel: 8
           launch_in_dev: ['PhantomJS'],
           launch_in_ci: ['PhantomJS', 'Chrome', 'Firefox', 'Safari', 'IE7', 'IE8', 'IE9']
+      reporting:
+        src: [
+          'spec/reporting/**/*.*'
+        ]
+        report_file: 'report.tap'
+        options:
+          launch_in_dev: ['PhantomJS'],
+          launch_in_ci: ['PhantomJS'],
+          reporter: "tap"
+          on_exit: (config, data, callback) =>
+            callback()
+
+            error = (msg) ->
+              console.error msg
+              process.exit(1)
+
+            #Test output file exists and contains correct report data
+            fs = require "fs"
+            if fs.existsSync('report.tap')
+              try
+                output = fs.readFileSync('report.tap', 'utf-8')
+                
+                if output.toString().indexOf("# ok") != 77
+                  error "Unable to find the output report.tap file"
+              finally
+                fs.unlinkSync 'report.tap'
+            else
+              error "Unable to find the output report.tap file"
 
   grunt.registerTask 'default', ['testem']

--- a/spec/reporting/Gruntfile.coffee
+++ b/spec/reporting/Gruntfile.coffee
@@ -1,0 +1,16 @@
+module.exports = (grunt) ->
+
+  grunt.loadNpmTasks 'grunt-contrib-testem'
+
+  # This is used to demonstrate the use of output files in your runner config
+  grunt.initConfig
+    testem:
+      reporting:
+        src: [
+          'spec/reporting/**/*.*'
+        ]
+        report_file: 'report.tap'
+        options:
+          launch_in_dev: ['PhantomJS'],
+          launch_in_ci: ['PhantomJS'],
+          reporter: "tap"

--- a/spec/reporting/spec.coffee
+++ b/spec/reporting/spec.coffee
@@ -1,0 +1,3 @@
+describe 'Environment', ->
+  it 'works', ->
+    


### PR DESCRIPTION
## My Issue

I had been having a few issues in trying to capture the output per testem configuration. In the Testem documentation it specifies that you should pipe the output ([here](https://github.com/airportyh/testem/blob/master/docs/use_with_jenkins.md)) from the runner into a file but the issue was that if I was running other targets as part of the build their output would obviously also get put into the output file too.
## My Solution

So it got me thinking, lets try write a wrapper for the output stream so we can effectively captcha the output coming from Testem. So the solution I came up with was to override the process.stdout.write function and redirect that to write directly to the reporting file while the Testem process is running:

```
testem:
    develop:
        src: [ 'spec/**/*.*']
        report_file: 'report.txt'
        options:
          launch_in_ci: ['PhantomJS']
```
