### PR TITLE
[upgrade] bumping connect to alleviate deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "testem": "~0.6.15",
     "sugar": "~1.3.8",
     "mincer": "~0.5.5",
-    "connect": "~2.8.5",
+    "connect": "~2.19.0",
     "coffee-script": ">=1.6.3"
   },
   "keywords": [


### PR DESCRIPTION
Recently, connect deprecated the use of `res.headerSent`. This older version of connect referenced here was causing an annoying deprecation warning to occur after upgrading other grunt-contrib-\* dependencies.

I'm bumping the version here to get everyone past the deprecation warning which should sort the issue out.
