### PR TITLE
Don't path.join if the path is already aboslute

### DIFF
--- a/tasks/grunt-contrib-testem.coffee
+++ b/tasks/grunt-contrib-testem.coffee
@@ -126,7 +126,7 @@ task = (grunt, mode) ->
     else
       cwd = environment.paths[0]
       grunt.file.expand({cwd: cwd}, @config("src") || []).forEach (match) ->
-        files[match] = Path.join(cwd, match)
+        files[match] = if match.charAt(0) == '/' then match else Path.join(cwd, match)
 
   # Options defaults
   options['launch_in_ci']  = [grunt.option('launch')] if grunt.option('launch')


### PR DESCRIPTION
`grunt-contrib-testem` should not blindly concat match paths because absolute urls then don't work. See my comments [here](https://github.com/inossidabile/grunt-contrib-testem/issues/13#issuecomment-59966056).
